### PR TITLE
[WIP] Inform user of missing handler for content type

### DIFF
--- a/src/gilbert/content.py
+++ b/src/gilbert/content.py
@@ -39,7 +39,11 @@ class Content(Schema):
         appropriate sub-class.
         """
         content_type = meta.get('content_type', cls.__name__)
-        klass = cls._types[content_type]
+        try:
+            klass = cls._types[content_type]
+        except KeyError:
+            msg = f"You attempted to create a page with type {content_type} but no class is registered to handle this content type"
+            raise TypeError(msg)
         return klass(name, content, meta)
 
 

--- a/src/gilbert/content.py
+++ b/src/gilbert/content.py
@@ -42,8 +42,8 @@ class Content(Schema):
         try:
             klass = cls._types[content_type]
         except KeyError:
-            msg = f"You attempted to create a page with type {content_type} but no class is registered to handle this content type"
-            raise TypeError(msg)
+            raise ValueError(f'You attempted to create a page with type "{content_type}"'
+                              ' but no class is registered to handle this content type')
         return klass(name, content, meta)
 
 


### PR DESCRIPTION
This is an attempt to inform the user that they have attempted to render content with a `content_type` that has no handler. Would appreciate feedback on what the best way to propagate the error message to the user is.