### PR TITLE
Fix for off by one error in YAML / Markdown content loading

### DIFF
--- a/src/gilbert/plugins/yaml.py
+++ b/src/gilbert/plugins/yaml.py
@@ -21,7 +21,7 @@ def load_yaml(path: Path) -> LoaderResult:
         meta = loader.get_data()
         # PyYAML Reader greedily consumes chunks from the stream.
         # We must recover any un-consumed data, as well as what's left in the stream.
-        data = loader.buffer[loader.pointer : -1] if loader.buffer else ""
+        data = loader.buffer[loader.pointer:] if loader.buffer else ""
         data += fin.read()
     return data, meta
 

--- a/test/plugin_data/test_content.yaml
+++ b/test/plugin_data/test_content.yaml
@@ -1,0 +1,67 @@
+title: Test more than 8192 characters
+content_type: MarkdownPage
+---
+We have 100 characters so far!
+
+After the next few long lines, we will have 1000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada
+And that makes one thousand characters!
+
+After the next few long lines, we will have 2000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus
+And now we have 2000 characters!!
+
+After the next few long lines, we will have 3000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus et
+And now we have 3000 characters!
+
+After the next few long lines, we will have 4000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus et
+And now we have 4000 characters
+
+After the next few long lines, we will have 5000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus et
+And now we have 5000 characters
+
+After the next few long lines, we will have 6000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus et
+And now we have 6000 characters
+
+After the next few long lines, we will have 7000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus et
+And now we have 7000 characters
+
+After the next few long lines, we will have 8000 characters:
+
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus luctus accumsan tortor posuere ac ut consequat semper viverra nam libero justo laoreet sit amet dictum
+Lorem ipsum dolor sit amet, mauris commodo quis imperdiet massa tincidunt nunc pulvinar sapien et ligula ullamcorper malesuada proin libero nunc consequat interdum varius sit amet mattis vulputate enim nulla aliquet porttitor lacus et
+And now we have 8000 characters
+
+After the next long line, we will have 8180 characters:
+
+And now after this really really really really really really really really really long line,
+we now have 8180 characters!
+
+PLEASE READ THIS LINE CAREFULLY

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from gilbert.plugins.yaml import load_yaml
+
+
+def test_yaml_plugin():
+    """Test the content being read from a YAML header, followed by Markdown
+
+    This is a regression test for a fix for an off-by-one issue where the 8192nd
+    character in the YAML/Markdown document could be missing from the rendered
+    Markdown due to the way the YAML loader buffer was being sliced.
+    """
+    path = Path(__file__).resolve().parent / "plugin_data" / "test_content.yaml"
+
+    data, meta = load_yaml(path)
+
+    assert meta == {
+        "title": "Test more than 8192 characters",
+        "content_type": "MarkdownPage"
+    }
+
+    # Ensure that "READ" doesn't become "REA":
+    assert "PLEASE READ THIS LINE CAREFULLY" in data


### PR DESCRIPTION
I ran into this bug, where the 8192nd character is skipped when rendering Markdown content from a YAML / Markdown file.

I know that not everyone likes pineapple on pizza 😄 , and nobody likes broken HTML markup either 😅 

From <https://blog.tinbrain.net/blog/django-formsets.html>:
```
<option value="3"Hawaiian</option>
```
Note the missing `>` before "Hawaiian" above ⬆️ 

The same issue presumably affects rendering of other pages with more than 8192 characters.

My real interest is in contributing instructions for "Let's Encrypt" to your Django install guide, but then I ran into this bug, so I thought I would address it first.  I can raise a PR for the "Let's Encrypt" instructions if you are interested. 😄 

<img width="418" alt="Screen Shot 2022-09-18 at 6 42 12 pm" src="https://user-images.githubusercontent.com/112796943/190893573-a6f3a675-0db8-450d-b423-e2b41f6128ed.png">

